### PR TITLE
Fix settings page functionality and navigation issues

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 
 export default function Index() {
+  const navigate = useNavigate();
   useIntersectionObserver();
 
   const features = [
@@ -96,25 +97,21 @@ export default function Index() {
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row animate-slide-up">
               <Button
-                asChild
+                onClick={() => navigate("/demo")}
                 size="lg"
                 className="transition-all duration-300 hover:scale-105 hover:shadow-lg"
               >
-                <Link to="/demo">
-                  <Play className="mr-2 h-4 w-4" />
-                  Try Live Demo
-                </Link>
+                <Play className="mr-2 h-4 w-4" />
+                Try Live Demo
               </Button>
               <Button
-                asChild
+                onClick={() => navigate("/languages")}
                 variant="outline"
                 size="lg"
                 className="transition-all duration-300 hover:scale-105 hover:shadow-lg"
               >
-                <Link to="/languages">
-                  <Globe className="mr-2 h-4 w-4" />
-                  Explore Languages
-                </Link>
+                <Globe className="mr-2 h-4 w-4" />
+                Explore Languages
               </Button>
             </div>
           </div>
@@ -288,15 +285,13 @@ export default function Index() {
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <Button
-                asChild
+                onClick={() => navigate("/demo")}
                 size="lg"
                 variant="secondary"
                 className="transition-all duration-300 hover:scale-105 hover:shadow-lg group"
               >
-                <Link to="/demo">
-                  Start Demo
-                  <ArrowRight className="ml-2 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
-                </Link>
+                Start Demo
+                <ArrowRight className="ml-2 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
               </Button>
             </div>
           </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -23,7 +23,6 @@ import {
 } from "lucide-react";
 
 export default function Index() {
-  const navigate = useNavigate();
   useIntersectionObserver();
 
   const features = [
@@ -97,21 +96,25 @@ export default function Index() {
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row animate-slide-up">
               <Button
-                onClick={() => navigate("/demo")}
+                asChild
                 size="lg"
                 className="transition-all duration-300 hover:scale-105 hover:shadow-lg"
               >
-                <Play className="mr-2 h-4 w-4" />
-                Try Live Demo
+                <Link to="/demo">
+                  <Play className="mr-2 h-4 w-4" />
+                  Try Live Demo
+                </Link>
               </Button>
               <Button
-                onClick={() => navigate("/languages")}
+                asChild
                 variant="outline"
                 size="lg"
                 className="transition-all duration-300 hover:scale-105 hover:shadow-lg"
               >
-                <Globe className="mr-2 h-4 w-4" />
-                Explore Languages
+                <Link to="/languages">
+                  <Globe className="mr-2 h-4 w-4" />
+                  Explore Languages
+                </Link>
               </Button>
             </div>
           </div>
@@ -285,13 +288,15 @@ export default function Index() {
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <Button
-                onClick={() => navigate("/demo")}
+                asChild
                 size="lg"
                 variant="secondary"
                 className="transition-all duration-300 hover:scale-105 hover:shadow-lg group"
               >
-                Start Demo
-                <ArrowRight className="ml-2 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+                <Link to="/demo">
+                  Start Demo
+                  <ArrowRight className="ml-2 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+                </Link>
               </Button>
             </div>
           </div>

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -135,7 +135,9 @@ export default function SettingsPage() {
   };
 
   const handleExport = () => {
-    const blob = new Blob([JSON.stringify(getSettings(), null, 2)], { type: "application/json" });
+    const blob = new Blob([JSON.stringify(getSettings(), null, 2)], {
+      type: "application/json",
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -277,7 +279,9 @@ export default function SettingsPage() {
                         key={voice.id}
                         className={cn(
                           "border-muted cursor-pointer transition-all duration-300 hover:scale-105 hover:shadow-lg hover:border-border scale-in-section group",
-                          selectedVoiceId === voice.id ? "border-foreground bg-muted/50" : "",
+                          selectedVoiceId === voice.id
+                            ? "border-foreground bg-muted/50"
+                            : "",
                         )}
                         onClick={() => setSelectedVoiceId(voice.id)}
                       >
@@ -289,7 +293,11 @@ export default function SettingsPage() {
                                 {voice.accent} Accent
                               </p>
                             </div>
-                            <Button size="sm" variant="outline" className="transition-all duration-300 hover:scale-105">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="transition-all duration-300 hover:scale-105"
+                            >
                               <Volume2 className="h-4 w-4" />
                             </Button>
                           </div>
@@ -392,7 +400,11 @@ export default function SettingsPage() {
                         <span className="ml-2 font-medium">2 days ago</span>
                       </div>
                     </div>
-                    <Button variant="outline" size="sm" className="w-full mt-3 transition-all duration-300 hover:scale-105">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-full mt-3 transition-all duration-300 hover:scale-105"
+                    >
                       <RefreshCw className="h-4 w-4 mr-2" />
                       Check for Updates
                     </Button>
@@ -501,11 +513,19 @@ export default function SettingsPage() {
                 <div>
                   <Label className="text-base">Data Management</Label>
                   <div className="mt-3 space-y-3">
-                    <Button onClick={handleExport} variant="outline" className="w-full justify-start transition-all duration-300 hover:scale-105">
+                    <Button
+                      onClick={handleExport}
+                      variant="outline"
+                      className="w-full justify-start transition-all duration-300 hover:scale-105"
+                    >
                       <Download className="h-4 w-4 mr-2" />
                       Export Settings
                     </Button>
-                    <Button onClick={handleClearCache} variant="outline" className="w-full justify-start transition-all duration-300 hover:scale-105">
+                    <Button
+                      onClick={handleClearCache}
+                      variant="outline"
+                      className="w-full justify-start transition-all duration-300 hover:scale-105"
+                    >
                       <RefreshCw className="h-4 w-4 mr-2" />
                       Clear Cache
                     </Button>
@@ -541,8 +561,17 @@ export default function SettingsPage() {
 
         {/* Save Settings */}
         <div className="flex justify-end space-x-4 mt-8">
-          <Button variant="outline" onClick={handleResetAll} className="transition-all duration-300 hover:scale-105">Reset to Defaults</Button>
-          <Button onClick={handleSave} className="transition-all duration-300 hover:scale-105">
+          <Button
+            variant="outline"
+            onClick={handleResetAll}
+            className="transition-all duration-300 hover:scale-105"
+          >
+            Reset to Defaults
+          </Button>
+          <Button
+            onClick={handleSave}
+            className="transition-all duration-300 hover:scale-105"
+          >
             <Save className="h-4 w-4 mr-2" />
             Save Settings
           </Button>

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -42,6 +42,7 @@ type SettingsData = {
 const SETTINGS_KEY = "liphera-settings";
 
 export default function SettingsPage() {
+  const [tab, setTab] = useState("audio");
   useIntersectionObserver();
   const [audioEnabled, setAudioEnabled] = useState(true);
   const [volume, setVolume] = useState([75]);
@@ -170,7 +171,7 @@ export default function SettingsPage() {
           </div>
         </div>
 
-        <Tabs defaultValue="audio" className="space-y-6">
+        <Tabs value={tab} onValueChange={setTab} className="space-y-6">
           <TabsList className="grid w-full grid-cols-4">
             <TabsTrigger value="audio" className="flex items-center space-x-2">
               <Volume2 className="h-4 w-4" />

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -26,6 +27,7 @@ import {
 } from "lucide-react";
 
 export default function SettingsPage() {
+  useIntersectionObserver();
   const [audioEnabled, setAudioEnabled] = useState(true);
   const [volume, setVolume] = useState([75]);
   const [speechRate, setSpeechRate] = useState([1.0]);
@@ -68,9 +70,9 @@ export default function SettingsPage() {
     <div className="min-h-screen pt-8 pb-24">
       <div className="container mx-auto px-4 max-w-4xl">
         {/* Header */}
-        <div className="mb-8">
+        <div className="mb-8 fade-in-section">
           <div className="flex items-center space-x-3 mb-4">
-            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-foreground">
+            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-foreground transition-all duration-300 hover:scale-110">
               <SettingsIcon className="h-6 w-6 text-background" />
             </div>
             <div>
@@ -113,7 +115,7 @@ export default function SettingsPage() {
 
           {/* Audio Settings */}
           <TabsContent value="audio" className="space-y-6">
-            <Card>
+            <Card className="scale-in-section transition-all duration-300 hover:shadow-lg">
               <CardHeader>
                 <CardTitle>Speech Synthesis</CardTitle>
                 <CardDescription>
@@ -186,7 +188,7 @@ export default function SettingsPage() {
                     {voiceOptions.map((voice) => (
                       <Card
                         key={voice.id}
-                        className="cursor-pointer hover:border-liphera-blue/50 transition-colors"
+                        className="border-muted cursor-pointer transition-all duration-300 hover:scale-105 hover:shadow-lg hover:border-border scale-in-section group"
                       >
                         <CardContent className="p-4">
                           <div className="flex items-center justify-between">
@@ -196,7 +198,7 @@ export default function SettingsPage() {
                                 {voice.accent} Accent
                               </p>
                             </div>
-                            <Button size="sm" variant="outline">
+                            <Button size="sm" variant="outline" className="transition-all duration-300 hover:scale-105">
                               <Volume2 className="h-4 w-4" />
                             </Button>
                           </div>
@@ -226,7 +228,7 @@ export default function SettingsPage() {
 
           {/* Processing Settings */}
           <TabsContent value="processing" className="space-y-6">
-            <Card>
+            <Card className="scale-in-section transition-all duration-300 hover:shadow-lg">
               <CardHeader>
                 <CardTitle>AI Processing</CardTitle>
                 <CardDescription>
@@ -243,11 +245,11 @@ export default function SettingsPage() {
                     {processingModes.map((mode) => (
                       <Card
                         key={mode.id}
-                        className={`cursor-pointer transition-colors ${
+                        className={`border-muted cursor-pointer transition-all duration-300 hover:scale-105 hover:shadow-lg ${
                           processingMode === mode.id
                             ? "border-foreground bg-muted/50"
                             : "hover:border-border"
-                        }`}
+                        } scale-in-section group`}
                         onClick={() => setProcessingMode(mode.id)}
                       >
                         <CardContent className="p-4 text-center">
@@ -299,7 +301,7 @@ export default function SettingsPage() {
                         <span className="ml-2 font-medium">2 days ago</span>
                       </div>
                     </div>
-                    <Button variant="outline" size="sm" className="w-full mt-3">
+                    <Button variant="outline" size="sm" className="w-full mt-3 transition-all duration-300 hover:scale-105">
                       <RefreshCw className="h-4 w-4 mr-2" />
                       Check for Updates
                     </Button>
@@ -311,7 +313,7 @@ export default function SettingsPage() {
 
           {/* Display Settings */}
           <TabsContent value="display" className="space-y-6">
-            <Card>
+            <Card className="scale-in-section transition-all duration-300 hover:shadow-lg">
               <CardHeader>
                 <CardTitle>Display Preferences</CardTitle>
                 <CardDescription>
@@ -357,7 +359,7 @@ export default function SettingsPage() {
                   </div>
                 </div>
 
-                <Card className="bg-muted/50 border-border">
+                <Card className="bg-muted/50 border-border fade-in-section transition-all duration-300 hover:shadow-lg">
                   <CardContent className="p-4">
                     <div className="flex items-center space-x-2 mb-2">
                       <Palette className="h-4 w-4 text-foreground" />
@@ -375,7 +377,7 @@ export default function SettingsPage() {
 
           {/* Privacy Settings */}
           <TabsContent value="privacy" className="space-y-6">
-            <Card>
+            <Card className="scale-in-section transition-all duration-300 hover:shadow-lg">
               <CardHeader>
                 <CardTitle>Privacy & Security</CardTitle>
                 <CardDescription>
@@ -408,17 +410,17 @@ export default function SettingsPage() {
                 <div>
                   <Label className="text-base">Data Management</Label>
                   <div className="mt-3 space-y-3">
-                    <Button variant="outline" className="w-full justify-start">
+                    <Button variant="outline" className="w-full justify-start transition-all duration-300 hover:scale-105">
                       <Download className="h-4 w-4 mr-2" />
                       Export Settings
                     </Button>
-                    <Button variant="outline" className="w-full justify-start">
+                    <Button variant="outline" className="w-full justify-start transition-all duration-300 hover:scale-105">
                       <RefreshCw className="h-4 w-4 mr-2" />
                       Clear Cache
                     </Button>
                     <Button
                       variant="destructive"
-                      className="w-full justify-start"
+                      className="w-full justify-start transition-all duration-300 hover:scale-105"
                     >
                       <Shield className="h-4 w-4 mr-2" />
                       Reset All Settings
@@ -426,7 +428,7 @@ export default function SettingsPage() {
                   </div>
                 </div>
 
-                <Card className="bg-green-50 border-green-200 dark:bg-green-950 dark:border-green-800">
+                <Card className="bg-green-50 border-green-200 dark:bg-green-950 dark:border-green-800 fade-in-section transition-all duration-300 hover:shadow-lg">
                   <CardContent className="p-4">
                     <div className="flex items-center space-x-2 mb-2">
                       <Shield className="h-4 w-4 text-green-600" />
@@ -447,8 +449,8 @@ export default function SettingsPage() {
 
         {/* Save Settings */}
         <div className="flex justify-end space-x-4 mt-8">
-          <Button variant="outline">Reset to Defaults</Button>
-          <Button>
+          <Button variant="outline" className="transition-all duration-300 hover:scale-105">Reset to Defaults</Button>
+          <Button className="transition-all duration-300 hover:scale-105">
             <Save className="h-4 w-4 mr-2" />
             Save Settings
           </Button>

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useState, useEffect } from "react";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses critical issues with the settings page where not all panes were working properly and navigation buttons (demo button, explore languages) were not connecting to their intended destinations. The users reported that the settings page was not functioning correctly and needed proper debugging and connection fixes.

## Code changes

- **Added persistent settings storage**: Implemented localStorage integration with proper save/load functionality using a `SETTINGS_KEY` constant
- **Enhanced state management**: Added `SettingsData` type definition and proper state initialization from localStorage
- **Implemented missing functionality**: Added working handlers for save, export, clear cache, and reset operations that were previously non-functional
- **Fixed voice selection**: Replaced broken `voiceGender` with proper `selectedVoiceId` state and click handlers
- **Added visual improvements**: Enhanced UI with hover effects, transitions, and proper styling using `cn` utility
- **Improved tab navigation**: Added controlled tab state management with `tab` and `setTab`
- **Added intersection observer**: Integrated `useIntersectionObserver` hook for better UX
- **Enhanced error handling**: Added try-catch blocks for localStorage operations with proper error logging

The settings page now has fully functional panes with proper data persistence, working buttons, and improved user experience through enhanced animations and interactions.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a9757d51b19446da8559541a4054a68d/swoosh-field)

👀 [Preview Link](https://a9757d51b19446da8559541a4054a68d-swoosh-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a9757d51b19446da8559541a4054a68d</projectId>-->
<!--<branchName>swoosh-field</branchName>-->